### PR TITLE
Add support for arrays in nearest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# JetBrains family
+.idea
+
+# OSX
+.DS_Store

--- a/osrm/core.py
+++ b/osrm/core.py
@@ -366,7 +366,7 @@ def nearest(coord, url_config=RequestConfig):
     host = check_host(url_config.host)
     url = '/'.join(
         [host, 'nearest', url_config.version, url_config.profile,
-         str(coord).replace('(', '').replace(')', '').replace(' ', '')]
+         ','.join(map(str, coord))]
         )
     rep = urlopen(url)
     parsed_json = json.loads(rep.read().decode('utf-8'))


### PR DESCRIPTION
Otherwise the example in readme doesn’t work:
```python
res = osrm.nearest([22.1021271845936,	41.5078687005805])
# will be rendered with brackets by str rather than parenthesis (and thus not replaced)
```