### PR TITLE
Fix #11, #13 (longitude/latitude order) and #9 (polyline case)

### DIFF
--- a/osrm/__init__.py
+++ b/osrm/__init__.py
@@ -48,7 +48,7 @@ class DefaultRequestConfig:
 
 RequestConfig = DefaultRequestConfig()
 
-Point = namedtuple("Point", ("latitude", "longitude"))
+Point = namedtuple("Point", ("longitude", "latitude"))
 
 from .core import match, simple_route, nearest, table, trip, _chain
 from .extra import AccessIsochrone

--- a/osrm/core.py
+++ b/osrm/core.py
@@ -237,12 +237,12 @@ def table(coords_src, coords_dest=None,
     ----------
 
     coords_src : list
-        A list of coord as (lat, long) , like :
+        A list of coord as (longitude, latitude) , like :
              list_coords = [(21.3224, 45.2358),
                             (21.3856, 42.0094),
                             (20.9574, 41.5286)] (coords have to be float)
     coords_dest : list, optional
-        A list of coord as (lat, long) , like :
+        A list of coord as (longitude, latitude) , like :
              list_coords = [(21.3224, 45.2358),
                             (21.3856, 42.0094),
                             (20.9574, 41.5286)] (coords have to be float)

--- a/osrm/core.py
+++ b/osrm/core.py
@@ -430,7 +430,7 @@ def trip(coords, steps=False, output="full",
     host = check_host(url_config.host)
 
     coords_request = \
-        "".join(['Polyline(',
+        "".join(['polyline(',
                  quote(polyline_encode([(c[1], c[0]) for c in coords])),
                  ')']) \
         if send_as_polyline \


### PR DESCRIPTION
This should fix issues #11 and #13 (both related to longitude/latitude order) and avoid the confusion created by the use of the `Point` namedtuple (see https://github.com/ustroetz/python-osrm/issues/13#issuecomment-406031194 for the wrong/current behavior).

This should also fix #9 by using the word `polyline` in lower case when building the url in the `trip` function.

I can split that PR in multiple ones if needed.